### PR TITLE
fix: graceful not found message when node_id does not exist in graph [SC-34003]

### DIFF
--- a/src/unpage/knowledge/graph.py
+++ b/src/unpage/knowledge/graph.py
@@ -89,6 +89,13 @@ class Graph:
             raise LookupError(f"Node {nid} not found in graph") from ex
         return node["data"]
 
+    async def get_node_safe(self, nid: str) -> Node | None:
+        """Get a node from the graph. Returns None if no Node found with nid."""
+        try:
+            return await self.get_node(nid)
+        except LookupError:
+            return None
+
     async def iter_nodes(self) -> AsyncIterator[Node]:
         """Get all nodes in the graph."""
         for _, node in self.digraph.nodes(data=True):

--- a/src/unpage/plugins/metrics/plugin.py
+++ b/src/unpage/plugins/metrics/plugin.py
@@ -29,7 +29,9 @@ class MetricsPlugin(Plugin, McpServerMixin):
     @tool()
     async def list_available_metrics_for_node(self, node_id: str) -> list[str] | str:
         """List the available metrics for a node."""
-        node = await self.context.graph.get_node(node_id)
+        node = await self.context.graph.get_node_safe(node_id)
+        if not node:
+            return f"Resource with node ID '{node_id}' not found"
 
         if not isinstance(node, HasMetrics):
             return f"{node.node_type} nodes do not support metrics"
@@ -53,10 +55,9 @@ class MetricsPlugin(Plugin, McpServerMixin):
 
         Metric names should be provided as a JSON array of strings.
         """
-        node = await self.context.graph.get_node(node_id)
-
+        node = await self.context.graph.get_node_safe(node_id)
         if not node:
-            return f"Resource with node ID {node_id} not found"
+            return f"Resource with node ID '{node_id}' not found"
 
         if not isinstance(node, HasMetrics):
             return f"{node.node_type} nodes do not support metrics"


### PR DESCRIPTION
before we had an uncaught LookupError that caused a gnarly stack trace. now we simply return a string saying we did not find the node.
