### PR TITLE
fix: reduce *_search_logs() response sizes [SC-34056]

### DIFF
--- a/src/unpage/plugins/datadog/plugin.py
+++ b/src/unpage/plugins/datadog/plugin.py
@@ -18,8 +18,7 @@ from unpage.plugins.datadog.nodes.datadog_team import DatadogTeam
 from unpage.plugins.mixins import KnowledgeGraphMixin, tool
 from unpage.plugins.mixins.mcp import McpServerMixin
 
-CLAUDE_DESKTOP_RESULT_MAX_LENGTH = 1048576
-RESULT_LIMIT = int(CLAUDE_DESKTOP_RESULT_MAX_LENGTH * 0.9)
+RESULT_LIMIT = 9 * 1024
 
 
 class DatadogPlugin(Plugin, KnowledgeGraphMixin, McpServerMixin):
@@ -149,7 +148,7 @@ class DatadogPlugin(Plugin, KnowledgeGraphMixin, McpServerMixin):
             continue_search=tt.under_time_out,
         ):
             content_length += len(log.model_dump_json(indent=6)) + 8
-            if content_length >= int(RESULT_LIMIT / 2):
+            if content_length >= RESULT_LIMIT:
                 truncated = True
                 break
             logs.append(log)

--- a/src/unpage/plugins/papertrail/plugin.py
+++ b/src/unpage/plugins/papertrail/plugin.py
@@ -10,8 +10,7 @@ from unpage.plugins.base import Plugin
 from unpage.plugins.mixins import McpServerMixin, tool
 from unpage.plugins.papertrail.client import PapertrailClient, PapertrailLogEvent
 
-CLAUDE_DESKTOP_RESULT_MAX_LENGTH = 1048576
-RESULT_LIMIT = int(CLAUDE_DESKTOP_RESULT_MAX_LENGTH * 0.9)
+RESULT_LIMIT = 9 * 1024
 
 
 class PapertrailSearchResult(BaseModel):
@@ -95,7 +94,7 @@ class PapertrailPlugin(Plugin, McpServerMixin):
             continue_search=tt.under_time_out,
         ):
             content_length += len(log.model_dump_json(indent=6)) + 8
-            if content_length >= int(RESULT_LIMIT / 2):
+            if content_length >= RESULT_LIMIT:
                 truncated = True
                 break
             logs.append(log)


### PR DESCRIPTION
previously we allowed a little over 900KB of logs to be returned and now we allow 9KB of logs to be returned.
