### PR TITLE
feat: simplify llm configuration [SC-34069] [SC-34066]

### DIFF
--- a/src/unpage/agent/analysis.py
+++ b/src/unpage/agent/analysis.py
@@ -89,14 +89,19 @@ class AnalysisAgent(dspy.Module):
         return self.mcp_server
 
     async def acall(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        with dspy.context(
-            lm=dspy.LM(
-                model=self.llm_settings["model"],
-                api_key=self.llm_settings["api_key"],
-                temperature=self.llm_settings["temperature"],
-                max_tokens=self.llm_settings["max_tokens"],
-                cache=self.llm_settings["cache"],
+        params = {
+            "model": self.llm_settings["model"],
+            "api_key": self.llm_settings["api_key"],
+            **(
+                {"temperature": self.llm_settings["temperature"]}
+                if not self.llm_settings["model"].startswith("bedrock/")
+                else {}
             ),
+            "max_tokens": self.llm_settings["max_tokens"],
+            "cache": self.llm_settings["cache"],
+        }
+        with dspy.context(
+            lm=dspy.LM(**params),
         ):
             return await super().acall(*args, **kwargs)
 

--- a/src/unpage/plugins/llm/plugin.py
+++ b/src/unpage/plugins/llm/plugin.py
@@ -1,11 +1,12 @@
 from typing import Any
 
+import litellm
 import questionary
 from litellm import acompletion
 
 from unpage.config.utils import PluginSettings
 from unpage.plugins.base import Plugin
-from unpage.utils import classproperty
+from unpage.utils import classproperty, select
 
 
 class LlmPlugin(Plugin):
@@ -41,33 +42,26 @@ class LlmPlugin(Plugin):
     async def interactive_configure(self) -> PluginSettings:
         """Interactive wizard for configuring the settings of this plugin."""
         defaults = self.default_plugin_settings
-
+        model_list = [
+            model if model.startswith(f"{provider}/") else f"{provider}/{model}"
+            for provider, models in litellm.models_by_provider.items()
+            for model in models
+        ]
         return {
-            "model": await questionary.text(
-                "Model", default=self.model or defaults["model"]
-            ).unsafe_ask_async(),
+            "model": await select(
+                "Model",
+                choices=model_list,
+                default=self.model or defaults["model"],
+                use_jk_keys=False,
+                use_search_filter=True,
+            ),
             "api_key": await questionary.password(
                 "API key",
                 default=self.api_key or defaults["api_key"],
             ).unsafe_ask_async(),
-            "temperature": float(
-                await questionary.text(
-                    "Model temperature (any float between 0 and 2)",
-                    default=str(self.temperature or defaults["temperature"]),
-                    validate=lambda v: v.replace(".", "").isdigit() and 0 <= float(v) <= 2,
-                ).unsafe_ask_async()
-            ),
-            "max_tokens": int(
-                await questionary.text(
-                    "Maximum number of tokens to generate for each response",
-                    default=str(self.max_tokens or defaults["max_tokens"]),
-                    validate=lambda v: v.isdigit() and 0 < int(v) <= 8192,
-                ).unsafe_ask_async()
-            ),
-            "cache": await questionary.confirm(
-                "Enable caching of responses",
-                default=self.cache or defaults["cache"],
-            ).unsafe_ask_async(),
+            "temperature": self.temperature or defaults["temperature"],
+            "max_tokens": self.max_tokens or defaults["max_tokens"],
+            "cache": self.cache or defaults["cache"],
         }
 
     async def validate_plugin_config(self) -> None:


### PR DESCRIPTION
* Provide a select box for the model, which pulls from the list of models litellm knows about and supports
* Ignore all the other configuration, except for auth token
* Do not send temperature for bedrock models and set AWS_REGION=us-east-1 if a region is not otherwise set in the environment.

The full set of configuration options is available in the config.yaml file and still supported by the llm plugin.
