### PR TITLE
docs: add pagerduty_resolve_incident tool [SC-34309]

### DIFF
--- a/docs/plugins/pagerduty.mdx
+++ b/docs/plugins/pagerduty.mdx
@@ -131,3 +131,19 @@ The PagerDuty plugin provides the following tools to Agents and MCP Clients:
 
   **Returns** `None`
 </Card>
+<br />
+
+<Card title="pagerduty_resolve_incident">
+  Resolve a PagerDuty incident.
+
+  **Arguments**
+  <ParamField path="incident_id" type="string" required>
+    The ID of the PagerDuty incident. Typically a string of uppercase letters and
+    numbers. For example "PGR0VU2", "PF9KMXH", or "Q2K78SNJ5U1VE1".
+  </ParamField>
+  <ParamField path="resolution_message" type="string">
+    An optional message to include with the resolution.
+  </ParamField>
+
+  **Returns** `None`
+</Card>

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -6,12 +6,21 @@ from fastmcp import Client
 @pytest.mark.asyncio
 async def test_docs_have_all_tools(mcp_client: Client) -> None:
     tools = await mcp_client.list_tools()
-    server_tool_names = [tool.name for tool in tools]
-    docs_dir = Path(__file__).parent.parent / "docs"
-    all_docs_content = ""
+    tool_info = {}
+    for tool in tools:
+        plugin, tool_name = tool.name.split("_", maxsplit=1)
+        if plugin not in tool_info:
+            tool_info[plugin] = []
+        tool_info[plugin].append(tool_name)
+    docs_dir = Path(__file__).parent.parent.parent / "docs"
     for filename in docs_dir.glob("**/*.mdx"):
-        all_docs_content += filename.read_text(encoding='utf-8')
-    for server_tool_name in server_tool_names:
-        assert server_tool_name in all_docs_content, (
-            f"Tool '{server_tool_name}' not found in documentation"
-        )
+        for plugin in tool_info:
+            if filename.name == f"{plugin}.mdx":
+                doc_content = filename.read_text(encoding="utf-8")
+                for tool_name in tool_info[plugin]:
+                    assert tool_name in doc_content, (
+                        f"Tool '{tool_name}' not found in documentation for plugin '{plugin}' in {filename}"
+                    )
+                tool_info.pop(plugin)
+                break
+    assert not tool_info, f"Tools not documented: {', '.join(tool_info.keys())}"

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -12,7 +12,7 @@ async def test_docs_have_all_tools(mcp_client: Client) -> None:
         if plugin not in tool_info:
             tool_info[plugin] = []
         tool_info[plugin].append(tool_name)
-    docs_dir = Path(__file__).parent.parent.parent / "docs"
+    docs_dir = Path(__file__).parent.parent.parent / "docs" / "plugins"
     for filename in docs_dir.glob("**/*.mdx"):
         for plugin in tool_info:
             if filename.name == f"{plugin}.mdx":

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import pytest
+from fastmcp import Client
+
+
+@pytest.mark.asyncio
+async def test_docs_have_all_tools(mcp_client: Client) -> None:
+    tools = await mcp_client.list_tools()
+    server_tool_names = [tool.name for tool in tools]
+    docs_dir = Path(__file__).parent.parent / "docs"
+    all_docs_content = ""
+    for filename in docs_dir.glob("**/*.mdx"):
+        all_docs_content += filename.read_text(encoding='utf-8')
+    for server_tool_name in server_tool_names:
+        assert server_tool_name in all_docs_content, (
+            f"Tool '{server_tool_name}' not found in documentation"
+        )


### PR DESCRIPTION
also add a test that checks all the tool names show up in their respective `<plugin_name>.mdx` file (to avoid this situation in the future maybe)