### PR TITLE
fix: papertrail_search_logs configurable timeout [SC-33981]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ User-facing documentation lives under docs/ and is built and published using Min
 
 ### Project context
 - Format: MDX files with YAML frontmatter
+- Mintlify hosts our documentation, and their MDX format is a superset of markdown with components like Cards and Accordians
 - Config: docs.json for navigation, theme, settings
 - Components: Mintlify components
 

--- a/docs/plugins/papertrail.mdx
+++ b/docs/plugins/papertrail.mdx
@@ -57,8 +57,16 @@ The Papertrail plugin provides the following tools to Agents and MCP Clients:
     The ending time for the search range (ISO 8601 timestamp). Logs generated
     at or before this time will be included in the results.
   </ParamField>
+  <ParamField path="timeout_seconds" type="integer" default="10">
+    The maximum number of seconds to wait for the search to complete. Defaults to 10 seconds.
+    Increase this value for more comprehensive results in large log volumes, or decrease it
+    for faster response times.
+  </ParamField>
 
-  **Returns** `list[dict]`: log events with details including timestamp, hostname, program, message, and metadata.
+  **Returns** `PapertrailSearchResult`: An object containing:
+  - `results`: Log events with details including timestamp, hostname, program, message, and metadata.
+  - `truncated`: Boolean indicating if results were truncated due to response size limits.
+  - `timed_out`: Boolean indicating if the search timed out based on the specified timeout.
 
   **Note**: Results are automatically truncated if they exceed response size limits to ensure optimal performance.
 </Card>

--- a/src/unpage/plugins/papertrail/plugin.py
+++ b/src/unpage/plugins/papertrail/plugin.py
@@ -64,7 +64,7 @@ class PapertrailPlugin(Plugin, McpServerMixin):
         query: str,
         min_time: AwareDatetime,
         max_time: AwareDatetime,
-        timeout: timedelta = timedelta(seconds=10),  # noqa: ASYNC109 Async function definition with a `timeout` parameter
+        timeout_seconds: int = 10,
     ) -> PapertrailSearchResult | str:
         """Search Papertrail for logs within a given time range
 
@@ -72,7 +72,7 @@ class PapertrailPlugin(Plugin, McpServerMixin):
             query (str): The search query.
             min_time (AwareDatetime): The starting time for the range within which to search.
             max_time (AwareDatetime): The ending time for the range within which to search.
-            timeout (timedelta): The maximum time to wait for the search to complete. Defaults to 10 seconds.
+            timeout_seconds (int): The maximum seconds to wait for the search to complete. Defaults to 10 seconds.
 
         Returns:
             PapertrailSearchResult: logs that matched the query and fit within response limit
@@ -86,7 +86,7 @@ class PapertrailPlugin(Plugin, McpServerMixin):
         class timeoutTracker:
             timed_out: bool = False
             start_time: AwareDatetime = datetime.now(UTC)
-            time_out: timedelta = timeout
+            time_out: timedelta = timedelta(seconds=timeout_seconds)
 
             def under_time_out(self, _: AwareDatetime | None) -> bool:
                 self.timed_out = (datetime.now(UTC) - self.start_time) > self.time_out


### PR DESCRIPTION
Previously we:
* had a 10 second overall search timeout
* combined timed_out and truncate, and that got confusing when something times out

Now we:
* enable the caller to set the timeout, and default to 10 seconds
* split up `timed_out` and `truncated` as separate fields in the response

An example that timed out but didn't truncate:

```
{"truncated":false,"timed_out":true,"results":[]}
```
