### PR TITLE
chore: update CONTRIBUTING.md to detail semantic releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,52 @@ MLFLOW_TRACKING_URI=http://127.0.0.1:5566 uv run unpage agent server
 ```
 
 And anything that uses the `unpage.agent` package.
+
+## Releases
+
+This project uses [semantic-release](https://python-semantic-release.readthedocs.io/) for automated versioning and publishing to PyPI. Releases are triggered automatically when PRs are merged to the main branch.
+
+### PR Title Requirements
+
+**Your PR title must follow the [Conventional Commits](https://www.conventionalcommits.org/) format** to trigger releases and generate proper changelog entries.
+
+#### Release-Triggering Prefixes
+
+- **`feat:`** - New features (triggers **minor** version bump: `0.1.0` → `0.2.0`)
+- **`fix:`** - Bug fixes (triggers **patch** version bump: `0.1.0` → `0.1.1`)  
+- **`perf:`** - Performance improvements (triggers **patch** version bump: `0.1.0` → `0.1.1`)
+
+#### Non-Release Prefixes
+
+These prefixes are allowed but **do not trigger releases**:
+
+- `build:` - Build system changes
+- `chore:` - Maintenance tasks
+- `ci:` - CI/CD changes
+- `docs:` - Documentation updates
+- `style:` - Code formatting changes
+- `refactor:` - Code refactoring
+- `test:` - Test additions or updates
+
+#### Examples
+
+✅ **Good PR titles:**
+- `feat: add dark mode toggle to settings`
+- `fix: resolve memory leak in graph builder`
+- `perf: optimize database query performance`
+- `docs: update installation instructions`
+
+❌ **Bad PR titles:**
+- `Update README` (missing prefix)
+- `feat add new feature` (missing colon)
+- `feature: add dark mode` (invalid prefix)
+
+### Release Process
+
+1. **Merge PR** with proper conventional commit title
+2. **Automated release** runs on main branch
+3. **Version bump** based on PR title prefix
+4. **Changelog update** generated automatically
+5. **PyPI publish** happens automatically
+
+If your PR doesn't need a release (documentation, tests, etc.), use the non-release prefixes listed above.


### PR DESCRIPTION
This PR updates `CONTRIBUTING.md` to explain how we use semantic releases.