### PR TITLE
fix: only include the 'generated_at' and 'message' fields in the log output [SC-34360]

### DIFF
--- a/src/unpage/plugins/papertrail/plugin.py
+++ b/src/unpage/plugins/papertrail/plugin.py
@@ -99,11 +99,12 @@ class PapertrailPlugin(Plugin, McpServerMixin):
             max_time=max_time,
             continue_search=tt.under_time_out,
         ):
-            content_length += len(log.model_dump_json(indent=6)) + 8
+            message = log.model_dump_json(indent=6, include={"generated_at", "message"})
+            content_length += len(message) + 8
             if content_length >= RESULT_LIMIT:
                 truncated = True
                 break
-            logs.append(log)
+            logs.append(message)
         return PapertrailSearchResult(
             results=logs,
             truncated=truncated,


### PR DESCRIPTION
This PR makes it less likely that the LLM will exceed its token limit by removing most of the metadata from the log messages we return from the Papertrail log search tool output.

(See SC-34360)