### PR TITLE
chore: schedule combine-pr github action [SC-34527]

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -1,6 +1,8 @@
 name: Combine Dependabot PRs
 
 on:
+  schedule:
+    - cron: '3 10 * * 1-5'  # 10:03 AM UTC, Monday through Friday
   workflow_dispatch:
     inputs:
       pr_type_filter:
@@ -28,6 +30,5 @@ jobs:
         uses: github/combine-prs@2909f404763c3177a456e052bdb7f2e85d3a7cb3 # v5.2.0
         with:
           ignore_label: "nocombine"
-          select_label: ${{ github.event.inputs.pr_type_filter }}
           labels: "dependencies, combined-pr, no-ticket"
           pr_title: "chore(deps): Combine Dependabot PRs"


### PR DESCRIPTION
The goal is to automatically create PRs like this one: https://github.com/aptible/unpage/pull/132

The PR will still need to be reviewed by one of the aptible/unpage maintainers, and one of the maintainers will have to manually take action so it passes the PR checks.

I set the job to run Dependabot on all the weekdays first thing in the morning (for North America timezones), because dependabot doesn't seem to run on a consistent day each week.
