### PR TITLE
feat: support third-party MCP servers [SC-34608]

### DIFF
--- a/src/unpage/agent/templates/fix_gha_build_failures.yaml
+++ b/src/unpage/agent/templates/fix_gha_build_failures.yaml
@@ -56,6 +56,24 @@ config:
               base_branch_name: The name of the target branch for the pull request
               commit_message: A commit message to use for the single commit
               pr_description: A description for the pull request
+    # mcpproxy:
+    #   enabled: true
+    #   settings:
+    #     mcp_servers:
+    #       github:
+    #         command: docker
+    #         args:
+    #           - run
+    #           - -i
+    #           - --rm
+    #           - -e
+    #           - GITHUB_PERSONAL_ACCESS_TOKEN
+    #           - ghcr.io/github/github-mcp-server
+    #           - stdio
+    #           - --read-only
+    #           # - --enable-command-logging
+    #         env:
+    #           GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
 
 test_payloads:
   build_failure:

--- a/src/unpage/agent/templates/investigate_azure_error_with_mcpproxy.yaml
+++ b/src/unpage/agent/templates/investigate_azure_error_with_mcpproxy.yaml
@@ -1,0 +1,46 @@
+
+description: >
+  Use this agent to investigate errors with Azure resources and post updates to MS teams using third-party MCP servers
+
+prompt: >
+  - Extract the Azure resource IDs and error details from the incoming alert
+  - Use the Azure MCP tools to fetch detailed information about the affected Azure resources
+  - Determine if a human SRE should investigate further
+  - Use the MS Teams MCP tools to post a status update to the #errors Microsoft Teams channel with:
+    - 1-2 sentences summarizing what happened and the suggested action, use emoji
+    - Summarize what you did, what you found, and why you made your recommendation
+    - Don't assume or make things up; say you don't know if you don't
+
+tools:
+  - "azure_*"
+  - "msteams_post_message"
+
+config:
+  plugins:
+    mcpproxy:
+      enabled: true
+      settings:
+        mcp_servers:
+          azure:
+            url: "https://azure.com/mcp"
+          msteams:
+            url: "https://teams.microsoft.com/l/channel/[TEAMS_CHANNEL_ID]/McpBot?groupId=[TEAM_ID]&tenantId=[TEAMS_APP_TENANT_ID]"
+
+test_payloads:
+  azure_error:
+    payload: >
+      {
+        "incident": {
+          "title": "Azure VM Error - Resource ID: /subscriptions/xxxx/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+          "description": "An error occurred with Azure VM vm1 in resource group rg1. Error code: VMExtensionProvisioningError. Please investigate.",
+          "created_at": "2024-06-01T12:00:00Z",
+          "status": "triggered",
+          "service": {
+            "id": "PABCDEF",
+            "type": "service_reference",
+            "summary": "Azure Monitoring Service",
+            "self": "https://api.pagerduty.com/services/PABCDEF",
+            "html_url": "https://example.pagerduty.com/service-directory/PABCDEF"
+          }
+        }
+      }

--- a/src/unpage/cli/agent/templates.py
+++ b/src/unpage/cli/agent/templates.py
@@ -1,6 +1,8 @@
 from rich import print
+from rich.console import Console
+from rich.table import Table
 
-from unpage.agent.utils import get_agent_templates
+from unpage.agent.utils import get_agent_template_description, get_agent_templates
 from unpage.cli.agent._app import agent_app
 from unpage.telemetry import client as telemetry
 
@@ -14,5 +16,8 @@ async def templates() -> None:
         }
     )
     print("Available agent templates:")
+    table = Table("Template Name", "Description")
     for template in sorted(get_agent_templates()):
-        print(f"* {template}")
+        table.add_row(template, get_agent_template_description(template).splitlines()[0])
+    console = Console()
+    console.print(table)

--- a/src/unpage/cli/mcp/tools/list.py
+++ b/src/unpage/cli/mcp/tools/list.py
@@ -2,6 +2,7 @@ import sys
 
 from rich import print
 
+from unpage.agent.utils import load_agent
 from unpage.cli.mcp.tools._app import tools_app
 from unpage.config import manager
 from unpage.knowledge import Graph
@@ -12,8 +13,16 @@ from unpage.telemetry import prepare_profile_for_telemetry
 
 
 @tools_app.command(name="list")
-async def list_tools() -> None:
-    """List all MCP tools available from enabled plugins."""
+async def list_tools(
+    agent_name: str | None = None,
+) -> None:
+    """List all MCP tools available from enabled plugins.
+
+    Parameters
+    ----------
+    agent_name:
+        Optional agent to load, which will use any configuration defined in that agent
+    """
     await telemetry.send_event(
         {
             "command": "mcp tools list",
@@ -21,6 +30,10 @@ async def list_tools() -> None:
         }
     )
     config = manager.get_active_profile_config()
+    if agent_name:
+        agent = load_agent(agent_name=agent_name)
+        if agent.config and agent.config.plugins:
+            config = config.merge_plugins(agent.config.plugins)
     plugins = PluginManager(config=config)
     context = Context(
         profile=manager.get_active_profile(),

--- a/src/unpage/mcp.py
+++ b/src/unpage/mcp.py
@@ -14,6 +14,7 @@ from unpage.config import Config, manager
 from unpage.knowledge import Graph
 from unpage.plugins import PluginManager
 from unpage.plugins.mixins.mcp import McpServerMixin
+from unpage.plugins.mixins.mcp_proxy import McpProxyMixin
 from unpage.telemetry import client as telemetry
 from unpage.utils import print
 
@@ -68,6 +69,9 @@ async def build_mcp_server(context: Context) -> FastMCP:
 
     for mcp_plugin in context.plugins.get_plugins_with_capability(McpServerMixin):
         mcp.mount(mcp_plugin.get_mcp_server(), prefix=mcp_plugin.name)
+
+    for mcp_proxy in context.plugins.get_plugins_with_capability(McpProxyMixin):
+        await mcp.import_server(await mcp_proxy.get_mcp_server_to_import())
 
     return mcp
 

--- a/src/unpage/plugins/mcpproxy/plugin.py
+++ b/src/unpage/plugins/mcpproxy/plugin.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.mcp_config import MCPConfig, MCPServerTypes
+from pydantic import Field
+
+from unpage.plugins.base import Plugin
+from unpage.plugins.mixins.mcp_proxy import McpProxyMixin
+
+
+class McpproxyPlugin(Plugin, McpProxyMixin):
+    mcp_servers: dict[str, MCPServerTypes] = Field(
+        description="Standard configuration for MCP servers", default_factory=dict
+    )
+
+    def __init__(
+        self, *args: Any, mcp_servers: dict[str, MCPServerTypes] | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.mcp_servers = mcp_servers if mcp_servers else {}
+
+    async def get_mcp_server_to_import(self) -> FastMCP[Any]:
+        if not self.mcp_servers:
+            return FastMCP[Any](self.name)
+        return FastMCP.as_proxy(
+            MCPConfig(mcpServers=self.mcp_servers), name="Unpage Proxy MCP Servers"
+        )

--- a/src/unpage/plugins/mixins/mcp_proxy.py
+++ b/src/unpage/plugins/mixins/mcp_proxy.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from fastmcp import FastMCP
+
+from unpage.plugins import PluginCapability
+
+
+class McpProxyMixin(PluginCapability):
+    """Capability for registering proxied MCP servers"""
+
+    def get_mcp(self) -> FastMCP[Any]:
+        """Creates a base FastMCP server for further configuration"""
+        return FastMCP[Any](self.name)
+
+    async def get_mcp_server_to_import(self) -> FastMCP[Any]:
+        raise NotImplementedError(
+            f"{self.name} plugin: must implement get_mcp_server_to_import method to be McpProxyMixin"
+        )


### PR DESCRIPTION
* New McpproxyPlugin that reads a standard mcpServers configuration and loads that into FastMCP as a set of proxies
* New `--use-test-payload <payload_name>` flag for `unpage agent run` to use the test_payloads defined in the agent yaml
* New `--agent-name <agent_name>` flag for `unpage mcp tools list` to include any tools defined with agent yaml configuration
