### PR TITLE
feat: support bash-like environment variable expansion in config.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "litellm>=1.75.5.post1",
     "dspy>=3.0.0,<4.0.0",
     "rich-gradient>=0.3.4",
+    "expandvars>=1.1.2",
 ]
 
 [tool.hatch.metadata]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,3 +1,10 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from expandvars import UnboundVariable
+
 from unpage.config import Config, PluginConfig, manager
 
 
@@ -7,3 +14,188 @@ def test_config_merge_plugins() -> None:
     assert "testplugin" in new_cfg.plugins
     assert new_cfg.plugins["testplugin"].enabled is True
     assert new_cfg.plugins["testplugin"].settings == {}
+
+
+def test_config_expand_env_vars_plugin_settings() -> None:
+    """Test environment variable expansion in plugin settings."""
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_REGION": "us-east-1",
+            "AWS_ACCESS_KEY": "AKIA123456789",
+            "DEBUG_MODE": "true",
+        },
+    ):
+        config_data: dict = {
+            "plugins": {
+                "aws": {
+                    "enabled": True,
+                    "settings": {
+                        "region": "$AWS_REGION",
+                        "access_key": "$AWS_ACCESS_KEY",
+                        "debug": "$DEBUG_MODE",
+                        "endpoints": ["https://$AWS_REGION.amazonaws.com"],
+                    },
+                }
+            }
+        }
+        config = Config(profile="test", file_path=Path("/tmp/test"), **config_data)
+        aws_settings = config.plugins["aws"].settings
+        assert aws_settings["region"] == "us-east-1"
+        assert aws_settings["access_key"] == "AKIA123456789"
+        assert aws_settings["debug"] == "true"
+        assert aws_settings["endpoints"] == ["https://us-east-1.amazonaws.com"]
+
+
+def test_config_expand_env_vars_nested_plugin_settings() -> None:
+    """Test environment variable expansion in nested plugin settings."""
+    with patch.dict(
+        os.environ,
+        {
+            "DB_HOST": "localhost",
+            "DB_PORT": "5432",
+        },
+    ):
+        config_data: dict = {
+            "plugins": {
+                "database": {
+                    "enabled": True,
+                    "settings": {
+                        "host": "$DB_HOST",
+                        "port": "$DB_PORT",
+                        "nested": {
+                            "connection_string": "postgresql://$DB_HOST:$DB_PORT/db",
+                        },
+                    },
+                }
+            }
+        }
+        config = Config(profile="test", file_path=Path("/tmp/test"), **config_data)
+        db_settings = config.plugins["database"].settings
+        assert db_settings["host"] == "localhost"
+        assert db_settings["port"] == "5432"
+        assert db_settings["nested"]["connection_string"] == "postgresql://localhost:5432/db"
+
+
+def test_config_expand_env_vars_with_defaults() -> None:
+    """Test environment variable expansion with default values."""
+    config_data: dict = {
+        "plugins": {
+            "service": {
+                "enabled": True,
+                "settings": {
+                    "timeout": "${TIMEOUT:-30}",
+                    "retries": "${RETRIES:-3}",
+                },
+            }
+        }
+    }
+    config = Config(profile="test", file_path=Path("/tmp/test"), **config_data)
+    service_settings = config.plugins["service"].settings
+    assert service_settings["timeout"] == "30"
+    assert service_settings["retries"] == "3"
+
+
+def test_config_expand_env_vars_nonexistent_var() -> None:
+    """Test behavior with nonexistent environment variables."""
+    config_data: dict = {
+        "plugins": {
+            "service": {
+                "enabled": True,
+                "settings": {
+                    "missing_var": "$NONEXISTENT_VAR",
+                },
+            }
+        }
+    }
+    # expandvars with nounset=True raises UnboundVariable if env var doesn't exist
+    with pytest.raises(UnboundVariable):
+        Config(profile="test", file_path=Path("/tmp/test"), **config_data)
+
+
+def test_config_expand_env_vars_mixed_types() -> None:
+    """Test that non-string types are preserved during expansion."""
+    with patch.dict(
+        os.environ,
+        {
+            "STRING_VAR": "test_value",
+        },
+    ):
+        config_data: dict = {
+            "plugins": {
+                "service": {
+                    "enabled": True,
+                    "settings": {
+                        "string_field": "$STRING_VAR",
+                        "number_field": 42,
+                        "boolean_field": True,
+                        "float_field": 3.14,
+                        "list_field": [1, 2, 3],
+                    },
+                }
+            }
+        }
+        config = Config(profile="test", file_path=Path("/tmp/test"), **config_data)
+        settings = config.plugins["service"].settings
+        assert settings["string_field"] == "test_value"
+        assert settings["number_field"] == 42
+        assert settings["boolean_field"] is True
+        assert settings["float_field"] == 3.14
+        assert settings["list_field"] == [1, 2, 3]
+
+
+def test_config_expand_env_vars_in_lists() -> None:
+    """Test environment variable expansion in lists within plugin settings."""
+    with patch.dict(
+        os.environ,
+        {
+            "SERVER1": "server1.com",
+            "SERVER2": "server2.com",
+        },
+    ):
+        config_data: dict = {
+            "plugins": {
+                "service": {
+                    "enabled": True,
+                    "settings": {
+                        "servers": [
+                            "$SERVER1",
+                            "$SERVER2",
+                            "static.com",
+                        ]
+                    },
+                }
+            }
+        }
+        config = Config(profile="test", file_path=Path("/tmp/test"), **config_data)
+        settings = config.plugins["service"].settings
+        assert settings["servers"] == ["server1.com", "server2.com", "static.com"]
+
+
+def test_config_expand_env_vars_complex_interpolation() -> None:
+    """Test complex environment variable expansion patterns."""
+    with patch.dict(
+        os.environ,
+        {
+            "ENV": "production",
+            "SERVICE_NAME": "unpage",
+            "VERSION": "1.0.0",
+        },
+    ):
+        config_data: dict = {
+            "plugins": {
+                "deployment": {
+                    "enabled": True,
+                    "settings": {
+                        "service_name": "${SERVICE_NAME}-${ENV}",
+                        "image": "${SERVICE_NAME}:${VERSION}",
+                        "environment": "$ENV",
+                    },
+                }
+            }
+        }
+        config = Config(profile="test", file_path=Path("/tmp/test"), **config_data)
+        settings = config.plugins["deployment"].settings
+        assert settings["service_name"] == "unpage-production"
+        assert settings["image"] == "unpage:1.0.0"
+        assert settings["environment"] == "production"

--- a/uv.lock
+++ b/uv.lock
@@ -702,6 +702,15 @@ wheels = [
 ]
 
 [[package]]
+name = "expandvars"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/64/a9d8ea289d663a44b346203a24bf798507463db1e76679eaa72ee6de1c7a/expandvars-1.1.2.tar.gz", hash = "sha256:6c5822b7b756a99a356b915dd1267f52ab8a4efaa135963bd7f4bd5d368f71d7", size = 70842, upload-time = "2025-09-12T10:55:20.929Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/e6/79c43f7a55264e479a9fbf21ddba6a73530b3ea8439a8bb7fa5a281721af/expandvars-1.1.2-py3-none-any.whl", hash = "sha256:d1652fe4e61914f5b88ada93aaedb396446f55ae4621de45c8cb9f66e5712526", size = 7526, upload-time = "2025-09-12T10:55:18.779Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3439,6 +3448,7 @@ dependencies = [
     { name = "dnspython" },
     { name = "dotenv" },
     { name = "dspy" },
+    { name = "expandvars" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastmcp" },
     { name = "graphviz" },
@@ -3486,6 +3496,7 @@ requires-dist = [
     { name = "dnspython", specifier = ">=2.7.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "dspy", specifier = ">=3.0.0,<4.0.0" },
+    { name = "expandvars", specifier = ">=1.1.2" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
     { name = "fastmcp", specifier = ">=2.10.1" },
     { name = "graphviz", specifier = ">=0.20.3" },


### PR DESCRIPTION
This PR adds support for referencing environment variables in `config.yaml`. For example:

```yaml
# ...
plugins:
  pagerduty:
    enabled: true
    settings:
      api_key: $PAGERDUTY_API_KEY
      default_from: "${PAGERDUTY_DEFAULT_FROM:-noreply@example.com}"  # Specify a default
```