### PR TITLE
chore: enable the pep8-naming linters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ select = [
     "F",     # pyflakes
     "FURB",  # refurb
     "I",     # isort
+    "N",     # pep8-naming
     "NPY",   # numpy
     "PERF",  # perflint
     "PTH",   # flake8-use-pathlib
@@ -105,6 +106,14 @@ select = [
     "SIM",   # flake8-simplify
     "TC",    # flake8-type-checking
     "UP",    # pyupgrade
+]
+
+[tool.ruff.lint.pep8-naming]
+classmethod-decorators = [
+    # Allow Pydantic's `@validator` decorator to be recognized as a class method.
+    "pydantic.validator",
+    # Allow the @classproperty decorator to be recognized as a class method.
+    "classproperty",
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/src/unpage/plugins/datadog/plugin.py
+++ b/src/unpage/plugins/datadog/plugin.py
@@ -134,7 +134,7 @@ class DatadogPlugin(Plugin, KnowledgeGraphMixin, McpServerMixin):
         truncated = False
         content_length = 0
 
-        class timeoutTracker:
+        class TimeoutTracker:
             timed_out: bool = False
             start_time: AwareDatetime = datetime.now(UTC)
 
@@ -142,7 +142,7 @@ class DatadogPlugin(Plugin, KnowledgeGraphMixin, McpServerMixin):
                 self.timed_out = (datetime.now(UTC) - self.start_time) > timedelta(seconds=10)
                 return not self.timed_out
 
-        tt = timeoutTracker()
+        tt = TimeoutTracker()
         async for log in self._client.search_logs(
             query=query if ":" in query else f"*:*{query}*",
             min_time=min_time,

--- a/src/unpage/plugins/papertrail/plugin.py
+++ b/src/unpage/plugins/papertrail/plugin.py
@@ -83,7 +83,7 @@ class PapertrailPlugin(Plugin, McpServerMixin):
         truncated = False
         content_length = 0
 
-        class timeoutTracker:
+        class TimeoutTracker:
             timed_out: bool = False
             start_time: AwareDatetime = datetime.now(UTC)
             time_out: timedelta = timedelta(seconds=timeout_seconds)
@@ -92,7 +92,7 @@ class PapertrailPlugin(Plugin, McpServerMixin):
                 self.timed_out = (datetime.now(UTC) - self.start_time) > self.time_out
                 return not self.timed_out
 
-        tt = timeoutTracker()
+        tt = TimeoutTracker()
         async for log in self._client.search(
             query=query,
             min_time=min_time,

--- a/src/unpage/plugins/solarwinds/client.py
+++ b/src/unpage/plugins/solarwinds/client.py
@@ -17,8 +17,8 @@ class SolarWindsLogEvent(BaseModel):
 class ResultPageInfo(BaseModel):
     """Pagination links"""
 
-    prevPage: str | None = None
-    nextPage: str | None = None
+    prevPage: str | None = None  # noqa: N815
+    nextPage: str | None = None  # noqa: N815
 
 
 class SearchResult(BaseModel):
@@ -27,7 +27,7 @@ class SearchResult(BaseModel):
     logs: list[SolarWindsLogEvent]
     """An array of hashes of log events (one hash per event)"""
 
-    pageInfo: ResultPageInfo
+    pageInfo: ResultPageInfo  # noqa: N815
 
 
 class SolarWindsClient(httpx.AsyncClient):

--- a/src/unpage/plugins/solarwinds/plugin.py
+++ b/src/unpage/plugins/solarwinds/plugin.py
@@ -94,7 +94,7 @@ class SolarWindsPlugin(Plugin, McpServerMixin):
         truncated = False
         content_length = 0
 
-        class timeoutTracker:
+        class TimeoutTracker:
             timed_out: bool = False
             start_time: AwareDatetime = datetime.now(UTC)
             time_out: timedelta = timedelta(seconds=timeout_seconds)
@@ -106,7 +106,7 @@ class SolarWindsPlugin(Plugin, McpServerMixin):
         if self._client is None:
             return "SolarWinds client not initialized. Please check your token and datacenter configuration."
 
-        tt = timeoutTracker()
+        tt = TimeoutTracker()
         async for log in self._client.search(
             query=query,
             min_time=min_time,

--- a/src/unpage/utils.py
+++ b/src/unpage/utils.py
@@ -290,7 +290,7 @@ def import_submodules(
             import_submodules(full_name)
 
 
-class classproperty[T]:
+class classproperty[T]:  # noqa: N801
     """
     Decorator that converts a method with a single cls argument into a property
     that can be accessed directly from the class.
@@ -389,11 +389,12 @@ def camel_to_snake(s: str) -> str:
     return re.sub(r"(?<!^)(?=[A-Z])", "_", s).lower()
 
 
+# Define a constant for redacted content
+REDACTED = "REDACTED"
+
+
 def strip_secrets(data: dict[str, Any]) -> dict[str, Any]:
     """Strip secrets from a dictionary."""
-
-    # Define a constant for redacted content
-    REDACTED = "REDACTED"
 
     def _visit(_path: tuple[str, ...], key: str, value: Any) -> bool | tuple[str, Any]:  # noqa: ANN401
         if key in ("passphrase", "connection_url"):


### PR DESCRIPTION
This PR enables Ruff's `pep8-naming` linter and addresses all of the resulting violations.