### PR TITLE
fix: some bugs with --profile [SC-34956]

### DIFF
--- a/src/unpage/cli/_app.py
+++ b/src/unpage/cli/_app.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Annotated
 
 import rich
@@ -34,7 +35,7 @@ def _app_launcher(
 ) -> None:
     # Let the user know when they're overriding the active profile.
     if profile != manager.get_active_profile():
-        rich.print(f"[blue]Active profile: {profile}[/blue]")
+        rich.print(f"[blue]Active profile: {profile}[/blue]", file=sys.stderr)
 
     with manager.active_profile(profile):
         app(tokens)

--- a/src/unpage/cli/agent/quickstart.py
+++ b/src/unpage/cli/agent/quickstart.py
@@ -274,6 +274,7 @@ async def _configure_plugins(
             },
         },
     )
+    cfg.save()
     rich.print("")
     return cfg
 


### PR DESCRIPTION
* print "Active profile: ..." message to stderr so it doesn't interfere with stdio protocol for mcp server
* ensure we save the config file created in `unpage agent quickstart`
