### PR TITLE
fix: agent quickstart bugs with profile and rootly [SC-34970]

### DIFF
--- a/src/unpage/cli/agent/actions.py
+++ b/src/unpage/cli/agent/actions.py
@@ -22,7 +22,7 @@ async def create_agent(agent_name: str, overwrite: bool, template: str) -> Path:
 
     # Create the agents directory if it doesn't exist
     agents_dir = config_dir / "agents"
-    agents_dir.mkdir(exist_ok=True)
+    agents_dir.mkdir(exist_ok=True, parents=True)
 
     # Create the agent file path
     agent_file = agents_dir / f"{agent_name}.yaml"

--- a/src/unpage/cli/agent/quickstart.py
+++ b/src/unpage/cli/agent/quickstart.py
@@ -467,27 +467,35 @@ async def _demo_an_incident(agent: Agent, plugin_manager: PluginManager, e: Comm
         title: str
         func: Callable[[], Awaitable[str | None]]
 
-    pd = cast("PagerDutyPlugin", plugin_manager.get_plugin("pagerduty"))
-    rootly = cast("RootlyPlugin", plugin_manager.get_plugin("rootly"))
-
-    options = [
-        PayloadOption(
-            title="Provide a PagerDuty incident ID or URL",
-            func=lambda: _provide_incident_id_or_url(pd),
-        ),
-        PayloadOption(
-            title="Select from a list of 20 most recent PagerDuty incidents",
-            func=lambda: _select_from_recent_incidents(pd),
-        ),
-        PayloadOption(
-            title="Provide a Rootly incident ID or URL",
-            func=lambda: _provide_rootly_incident_id_or_url(rootly),
-        ),
-        PayloadOption(
-            title="Select from a list of 20 most recent Rootly incidents",
-            func=lambda: _select_from_recent_rootly_incidents(rootly),
-        ),
-    ]
+    options = []
+    if plugin_manager.config_has_plugin("pagerduty"):
+        pd = cast("PagerDutyPlugin", plugin_manager.get_plugin("pagerduty"))
+        options.extend(
+            [
+                PayloadOption(
+                    title="Provide a PagerDuty incident ID or URL",
+                    func=lambda: _provide_incident_id_or_url(pd),
+                ),
+                PayloadOption(
+                    title="Select from a list of 20 most recent PagerDuty incidents",
+                    func=lambda: _select_from_recent_incidents(pd),
+                ),
+            ]
+        )
+    if plugin_manager.config_has_plugin("rootly"):
+        rootly = cast("RootlyPlugin", plugin_manager.get_plugin("rootly"))
+        options.extend(
+            [
+                PayloadOption(
+                    title="Provide a Rootly incident ID or URL",
+                    func=lambda: _provide_rootly_incident_id_or_url(rootly),
+                ),
+                PayloadOption(
+                    title="Select from a list of 20 most recent Rootly incidents",
+                    func=lambda: _select_from_recent_rootly_incidents(rootly),
+                ),
+            ]
+        )
 
     if agent.test_payloads:
         options.insert(

--- a/src/unpage/plugins/base.py
+++ b/src/unpage/plugins/base.py
@@ -75,6 +75,9 @@ class PluginManager:
         """Return the plugin class for a given name."""
         return REGISTRY[name]
 
+    def config_has_plugin(self, name: str) -> bool:
+        return name in self._config.plugins
+
     def get_plugin(self, name: str, config: PluginConfig | None = None) -> Plugin:
         """Return the configured plugin for a given name."""
         config = config or self._config.plugins[name]

--- a/tests/cli/agent/test_actions.py
+++ b/tests/cli/agent/test_actions.py
@@ -42,7 +42,7 @@ async def test_create_agent_success(mock_get_template, mock_get_dir, mock_confir
         mock_get_template.assert_called_once_with("default")
 
         # Verify directory creation
-        mock_mkdir.assert_called_once_with(exist_ok=True)
+        mock_mkdir.assert_called_once_with(exist_ok=True, parents=True)
 
         # Verify file was written
         mock_write.assert_called_once_with("# Test agent template\nname: test", encoding="utf-8")


### PR DESCRIPTION
* `unpage agent quickstart --profile` threw exception when making the `agents/` directory, because we do that before initializing config. fix is to allow the agent creation to make parent folder.
* `unpage agent quickstart` threw exception when asking user to what payload if either of the pagerduty or rootly plugins were not part of the configuration. update is to only include those options if the plugins are configured.
